### PR TITLE
Remove "Digital" option from ActionPlanDeliveryMethod model

### DIFF
--- a/NCS.DSS.ActionPlan/ReferenceData/ActionPlanDeliveryMethod.cs
+++ b/NCS.DSS.ActionPlan/ReferenceData/ActionPlanDeliveryMethod.cs
@@ -4,7 +4,6 @@
     {
         Paper = 1,
         Email = 2,
-        Digital = 3,
         Other = 99
     }
 }


### PR DESCRIPTION
Following the decommissioning of Digital Action Plans from the NCS website, the 'Digital - 3' option needs removing for the ActionPlanDeliveryMethod field. This has been removed from the model in this PR